### PR TITLE
refactor: to silk-engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,14 @@
-# InsightQL
-simple, portable stream processing engine.  
+# Silk Engine
+simple library for event processing with Kafka. 
 inspired by Robinhood's [Faust](https://faust.readthedocs.io/en/latest/introduction.html)
 
 ## Project vision
 
-**Distributed**  
-Simple integration into microservices because of the independence of each **insightQL** instance. Deploy as many as you need! 
+**Flexible**  
+Freedom of creating multiple **Silk Engines** and subscribing to as many topics as needed. 
 
 **Read optimized**  
 Designed to perform complex read queries, and is not designed to execute writes and updates to databases.
-
-**Flexible**  
-Freedom of creating multiple consumers and subscribing to as many topics as needed.
 
 **Single instance**  
 No need to distribute the preparation and execution of asynchronous jobs. This event processing engine assumes both roles.
@@ -35,22 +32,22 @@ Event-driven architecture allows the data in our cache to remain fresh and consi
 ## Key highlights
 
 **Event process pipeline**  
-InsightQL is a great way to coordinate and execute event-driven jobs. The way our system works is like this: 
+Silk Engine is a great way to coordinate and execute event-driven jobs. The way our system works is like this: 
 ```mermaid
 flowchart LR;
-MessageDataModel --> Agent
-Job --> Agent
-Agent --> MessageEvent
+MessageData --> Merchant
+Job --> Merchant
+Merchant --> MessageEvent
 MessageEvent --> Topic
 ```
-As we can see, an Agent should always be fixed to a specific message event in the Kafka topic (i.e OrderPlaced, OrderDelivered). This structure allows a consistent serialization of messages with InsightQL and distributed processing of message events. We shouldn't be using a model meant for placed orders on messages about delivered orders. This atomicity is enforced by either validating the Kafka message header attribute `event-type` or the message key to the MessageEvent parameter passed into the Agent.  
-This makes sure that we **DO NOT** use the **_single user-defined MessageDataModel_** to **serialize** several **_different types of messages_** from a kafka topic.
+As we can see, a Merchant should always be fixed to a specific message event in the Kafka topic (i.e OrderPlaced, OrderDelivered). This structure allows a consistent serialization of messages with Silk Engine and distributed processing of message events. We shouldn't be using a model meant for placed orders on messages about delivered orders. This atomicity is enforced by either validating the Kafka message header attribute `event-type` or the message key to the MessageEvent parameter passed into the Merchant.  
+This makes sure that we **DO NOT** use the **_single user-defined MessageData_** to **serialize** several **_different types of messages_** from a kafka topic.
 
 
 **Centralized Message Data**  
-InsightQL takes your data model to serialize the messages consumed by using a single instance of the data model provided. This greatly resembles the Singleton pattern. The single instance is used to store valid serialized message data and wipe all data after Agent job execution for easy reuse. This simulates an in-memory cache with cache invalidation for each Agent to use as they prepare, execute, and cleanup a job.
+Silk Engine takes your data model to serialize the messages consumed by using a single instance of the data model provided. This greatly resembles the Singleton pattern. The single instance is used to store valid serialized message data and wipe all data after Merchant job execution for easy reuse. This simulates an in-memory cache with cache invalidation for each Merchant to use as they prepare, execute, and cleanup a job.
 
-This single instance works well with our system because they are assigned *one per agent* and *one agent per message event* (as mentioned earlier: ensures consistent serialization of messages), another thing that allows this single instance to thrive is the sequential events from Kafka that mitigate any race conditions on our data object. Our `CentralizedSingleInstance` type defines how our data objects work.
+This single instance works well with our system because they are assigned *one per merchant* and *one merchant per message event* (as mentioned earlier: ensures consistent serialization of messages), another thing that allows this single instance to thrive is the sequential events from Kafka that mitigate any race conditions on our data object. Our `CentralizedSingleInstance` type defines how our data objects work.
 ```typescript
 export type CentralizedSingleInstance = {
   [keys: string]: any;
@@ -66,16 +63,16 @@ export type CentralizedSingleInstance = {
   validInstance(): boolean;
 };
 ```
-This single instance data object for each agent has many advantages to our engine:
+This single instance data object for each merchant has many advantages to our engine:
 - Absolute control over the data flow coming from messages.
 - Centralized cache with easy access.
 - Lightweight and optimized performance for job storage as creating multiple instances of your data model for each message recieved could be costly.
 
 ## Benchmarks
 
-This is the estimated performance overhead for some of InsightQL's processes and workflow. 
+This is the estimated performance overhead for some of Silk Engine's processes and workflow. 
 
-**Event Message Processing (Single Agent)**: 0.018ms
+**Event Message Processing (Single Merchant)**: 0.018ms
 
-**Event Message Processing (Multiple Agents: 5)**: 0.042ms
+**Event Message Processing (Multiple Merchants: 5)**: 0.042ms
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -3,4 +3,4 @@
  - Modularized objects and types. Implemented abstraction for app configuring, data defining, and initializing.
  - Implemented storage. In-memory key/value store available by default. Optional **redis** configuration also integrated.
  - Proper usage of running async functions from within loops. Optimization to message coordination process. Started benchmarking.
- - Enforced message event validation on Agent and message consumed. Seperated redis and inmem within App for easier abstraction. Furthered benchmarking and testing redis caching.
+ - Enforced message event validation on Merchant and message consumed. Seperated redis and inmem within App for easier abstraction. Furthered benchmarking and testing redis caching.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "insightql",
+  "name": "silk-engine3",
   "type": "module",
   "main": "dist/main.js",
   "types": "dist/main.d.ts",

--- a/src/__test__/benchmark.perf.ts
+++ b/src/__test__/benchmark.perf.ts
@@ -1,6 +1,6 @@
 import { EachMessagePayload, KafkaMessage } from 'kafkajs';
-import Agent from '../kafka/models/agent.js';
-import MessageData from '../kafka/models/messageData.js';
+import Merchant from '../kafka/models/Merchant.js';
+import MessageData from '../kafka/models/MessageData.js';
 
 class Data extends MessageData {
   ordertime!: number;
@@ -15,12 +15,12 @@ class Data extends MessageData {
   orderidk!: number;
 }
 
-const agent = new Agent('mock-topic', 'testEvent', new Data(), async (messageData: Data): Promise<void> => {
+const merchant = new Merchant('mock-topic', 'testEvent', new Data(), async (messageData: Data): Promise<void> => {
   /* await app.db.set('order-id', message.orderid); */
   // use redis cache
 });
 
-let mockAgents = [agent];
+let mockMerchants = [merchant];
 const mockMessage: EachMessagePayload = {
   topic: 'mock-topic',
   partition: 4,
@@ -44,11 +44,11 @@ async function coordinateMessage(messagePayload: EachMessagePayload): Promise<vo
   const jsonData = JSON.parse(String(message.value)); // message.value into generic object
   const key = String(message.key);
   await Promise.all(
-    mockAgents.map(async agent => {
-      // run async agents in parallel
-      const validateSrc = agent.validateHeader ? message.headers : key;
-      if (topic === agent.topic && validateSrc === agent.event && jsonData != undefined) {
-        await agent.executeAgent(jsonData);
+    mockMerchants.map(async merchant => {
+      // run async merchants in parallel
+      const validateSrc = merchant.validateHeader ? message.headers : key;
+      if (topic === merchant.topic && validateSrc === merchant.event && jsonData != undefined) {
+        await merchant.execute(jsonData);
       }
     }),
   );
@@ -61,7 +61,7 @@ for (let i = 0; i < 100; i++) {
   const time = end - start;
   singleAvg += time;
 }
-mockAgents = [agent, agent, agent, agent, agent];
+mockMerchants = [merchant, merchant, merchant, merchant, merchant];
 let multipleAvg = 0;
 for (let i = 0; i < 100; i++) {
   const start = performance.now();
@@ -72,6 +72,6 @@ for (let i = 0; i < 100; i++) {
 }
 
 // eslint-disable-next-line no-console
-console.log('event processing (1 agent, 1 job each):' + (singleAvg / 100).toFixed(3) + 'ms');
+console.log('event processing (1 merchant, 1 job each):' + (singleAvg / 100).toFixed(3) + 'ms');
 // eslint-disable-next-line no-console
-console.log('event processing (5 agent(s), 1 job each):' + (multipleAvg / 100).toFixed(3) + 'ms');
+console.log('event processing (5 merchants, 1 job each):' + (multipleAvg / 100).toFixed(3) + 'ms');

--- a/src/app.ts
+++ b/src/app.ts
@@ -10,7 +10,7 @@ import { Config } from './config.js';
 import { Application } from 'express';
 import * as redis from 'redis';
 import express from 'express';
-import KafkaConsumer from './kafka/models/consumer.js';
+import KafkaConsumer from './kafka/models/SilkEngine.js';
 import { Server } from 'http';
 import { createDatabase } from './db/inMemory.js';
 import { Database, redisConfig } from './db/types.js';

--- a/src/kafka/models/Merchant.ts
+++ b/src/kafka/models/Merchant.ts
@@ -1,8 +1,8 @@
 import { logger } from '../../utils/logger.js';
-import { AgentType, JobType } from '../types.js';
-import MessageData from './messageData.js';
+import { MerchantType, JobType } from '../types.js';
+import MessageData from './MessageData.js';
 
-export default class Agent implements AgentType {
+export default class Merchant implements MerchantType {
   public topic: string;
   public event: string;
   public model: MessageData;
@@ -19,7 +19,7 @@ export default class Agent implements AgentType {
     }
   }
 
-  public async executeAgent(messageData: Record<string, unknown>): Promise<void> {
+  public async execute(messageData: Record<string, unknown>): Promise<void> {
     const data = Object.assign(this.model, messageData); // serialize generic object properties to single model instance aka cache message data
     if (!this.model.validInstance()) {
       // validate the serialization

--- a/src/kafka/types.ts
+++ b/src/kafka/types.ts
@@ -1,22 +1,22 @@
 import { EachMessagePayload } from 'kafkajs';
 
-export type KafkaConsumerType = {
+export type SilkEngineType = {
   consumerId: string;
 
-  startConsumer(): Promise<void>;
+  start(): Promise<void>;
   shutdown(): Promise<void>;
   subscribe(kafkaTopic: string, fromBeginning: boolean): void;
   /**
-   * Adds an agent to the array, these agents are used to coordinate and execute jobs
-   * @param agent agent to add to kafka consumer
+   * Adds a merchant to the workflow for coordinating and executing jobs
+   * @param merchant
    */
-  addAgent(agent: AgentType): void;
-  getAgents(): AgentType[];
+  addMerchant(merchant: MerchantType): void;
+  getMerchants(): MerchantType[];
   /**
-   * handles message serialization and coordinating job execution for agents based on topic of message consumed
+   * handles message serialization and coordinating job execution for merchants based on topic of message consumed
    * @param message message to serialize
    */
-  coordinateMessage(message: EachMessagePayload): Promise<void>;
+  coordinate(message: EachMessagePayload): Promise<void>;
 };
 
 export type CentralizedSingleInstance = {
@@ -37,13 +37,13 @@ export type JobType = {
   (...args: any): Promise<void>;
 };
 
-export type AgentType = {
+export type MerchantType = {
   topic: string;
   event: string;
   model: CentralizedSingleInstance;
   job: JobType;
 
-  executeAgent(messageData: Record<string, unknown>): Promise<void>;
+  execute(messageData: Record<string, unknown>): Promise<void>;
 };
 
 export type KafkaConfig = {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,34 +1,24 @@
 /**
- * example for how to use insightQL
- *  - create consumer object
- *  - subscribe consumer to topics
+ * example for how to use SilkEngine
+ *  - create silkengine instance
+ *  - subscribe engine to topics
  *  - define model to deserialize messages
- *  - define agent and asynchronous job to execute
- *  - add agent to consumer workflow
- *  - add consumer to app
- *  - init app
+ *  - define merchant and asynchronous job to execute
+ *  - add merchant to engine workflow
+ *  - start engine
  */
-import app from './app.js';
-import { Config } from './config.js';
-import Agent from './kafka/models/agent.js';
-import KafkaConsumer from './kafka/models/consumer.js';
-import MessageData from './kafka/models/messageData.js';
+import Merchant from './kafka/models/Merchant.js';
+import SilkEngine from './kafka/models/SilkEngine.js';
+import MessageData from './kafka/models/MessageData.js';
 
-// enable and configure redis
-app.useRedis({
-  host: Config.redisHost,
-  port: Config.redisPort,
-  username: Config.redisUsername,
-  password: Config.redisPassword,
-});
 // kafka consumer config
-const consumer = new KafkaConsumer({
-  saslUsername: Config.kafkaSASLUsername,
-  saslPassword: Config.kafkaSASLPassword,
-  broker: Config.kafkaBroker,
+const engine = new SilkEngine({
+  saslUsername: '',
+  saslPassword: '',
+  broker: '',
 });
 // subscribe to topics
-consumer.subscribe(Config.kafkaTopic);
+engine.subscribe('topic-test');
 // define data model to deserialize messages
 class MarkedBook extends MessageData {
   bookId!: number;
@@ -38,18 +28,12 @@ class MarkedBook extends MessageData {
   genre!: string;
   dateMarked!: string;
 }
-// create agent to handle topic messages with data model and asynchronous job
-const agent = new Agent(Config.kafkaTopic, '18', new MarkedBook(), async (messageData: MarkedBook): Promise<void> => {
+// create merchant to handle topic messages with data model and asynchronous job
+const merchant = new Merchant('topic-test', '18', new MarkedBook(), async (messageData: MarkedBook): Promise<void> => {
   const prefix = `user:${messageData.userId}:markedBooks`;
-  const db = app.getRedis();
-  await db.sAdd(prefix, JSON.stringify(messageData)); // use redis cache
-  const data = await db.sMembers(prefix);
-  // eslint-disable-next-line no-console
-  console.log({ user: messageData.userId, markedBooks: data.map(obj => JSON.parse(obj)) });
+  messageData.author = prefix;
 });
-// add agent to consumer
-consumer.addAgent(agent);
-// add consumer to app
-app.addConsumer(consumer);
-// init app
-app.startServer();
+// add merchant to engine
+engine.addMerchant(merchant);
+
+engine.start();


### PR DESCRIPTION
## Description
Refactored our library to '**Silk Engine**'. Derived from the silk road, as the stream of events is similar to the network of trade, goods, and ideas. 

This means our agents are now Merchants! Merchants are used on the Silk Engine to properly coordinate, serialize, and execute jobs. 
## Related issues, pull requests, and links
## Documentation
( ) No documentation is needed.
(x) Sufficient documentation is included in this PR.
( ) Documentation will be handled later....maybe...